### PR TITLE
[fix] Adjust scene number size so it can show numbers up to 999

### DIFF
--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -15,8 +15,8 @@ heading:before {
   float: left;
   text-align: right;
   display: block;
-  width: 40px;
-  margin-left: -67px; /* - (27 + width) */
+  width: 25px;
+  margin-left: -52px; /* - (27 + width) */
 
   /* scene numbering: */
   counter-increment: scene;


### PR DESCRIPTION
Avoid overlapping SM icons, now that they are closer to scene numbers
(see ep_SM).

This is part of the fixes for https://trello.com/c/9Ih5SiVJ/954.