### PR TITLE
[fix:styles] Disable styles affecting paste of long scripts

### DIFF
--- a/static/css/disable_on_paste.css
+++ b/static/css/disable_on_paste.css
@@ -1,0 +1,10 @@
+/* When these elements are the first ones of script they have no margin-top */
+#innerdocbody > div:first-of-type episode_name,
+#innerdocbody > div:first-of-type act_name,
+#innerdocbody > div:first-of-type sequence_name,
+#innerdocbody > div:first-of-type action,
+#innerdocbody > div:first-of-type character,
+#innerdocbody > div:first-of-type transition,
+#innerdocbody > div:first-of-type shot {
+  margin-top: 0px;
+}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -6,7 +6,6 @@ body{
 }
 */
 
-/* WARNING there are other styles for script elements dynamically set on fixSmallZooms.js */
 heading{
   display:block;
   text-transform: uppercase;
@@ -103,45 +102,33 @@ heading, action, character, parenthetical, dialogue, transition, shot{
 
 /* Dimensions of script elements*/
 @media (min-width : 464px) {
-  #innerdocbody:not(.pasting) action {
+  action {
     margin-top: 16px;
   }
 
-  #innerdocbody:not(.pasting) character {
+  character {
     margin-left: 152px;
     margin-right: 16px;
     margin-top: 16px;
   }
 
-  #innerdocbody:not(.pasting) parenthetical {
+  parenthetical {
     margin-left: 105px;
     margin-right: 154px;
   }
 
-  #innerdocbody:not(.pasting) dialogue {
+  dialogue {
     margin-left: 77px;
     margin-right: 111px;
   }
 
-  #innerdocbody:not(.pasting) transition {
+  transition {
     margin-left: 290px;
     margin-right: 36px;
     margin-top: 16px;
   }
 
-  #innerdocbody:not(.pasting) shot {
+  shot {
     margin-top: 32px;
   }
 }
-
-/* When these elements are the first ones of script they have no margin-top */
-#innerdocbody:not(.pasting) > div:first-of-type episode_name,
-#innerdocbody:not(.pasting) > div:first-of-type act_name,
-#innerdocbody:not(.pasting) > div:first-of-type sequence_name,
-#innerdocbody:not(.pasting) > div:first-of-type action,
-#innerdocbody:not(.pasting) > div:first-of-type character,
-#innerdocbody:not(.pasting) > div:first-of-type transition,
-#innerdocbody:not(.pasting) > div:first-of-type shot {
-  margin-top: 0px;
-}
-

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -2,6 +2,7 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var _ = require('ep_etherpad-lite/static/js/underscore');
 
 var scriptElementTransitionUtils = require("ep_script_element_transitions/static/js/utils");
+var pasteUtils = require('ep_script_copy_cut_paste/static/js/utils');
 
 var tags     = require('ep_script_elements/static/js/shared').tags;
 var sceneTag = require('ep_script_elements/static/js/shared').sceneTag;
@@ -24,7 +25,11 @@ var TIME_TO_UPDATE_CARET_ELEMENT = 900;
 // 'undo' & 'redo' are triggered by toolbar buttons; other events are triggered by key shortcuts
 var UNDO_REDO_EVENTS = ['handleKeyEvent', 'undo', 'redo']
 
-var cssFiles = ['ep_script_elements/static/css/editor.css'];
+var CSS_TO_BE_DISABLED_ON_PASTE = 'ep_script_elements/static/css/disable_on_paste.css';
+var cssFiles = [
+  'ep_script_elements/static/css/editor.css',
+  CSS_TO_BE_DISABLED_ON_PASTE,
+];
 
 // All our tags are block elements, so we just return them.
 exports.aceRegisterBlockElements = function() {
@@ -184,6 +189,8 @@ exports.aceInitialized = function(hook, context) {
 
   editorInfo.ace_removeSceneTagFromSelection = _(removeSceneTagFromSelection).bind(context);
   editorInfo.ace_doInsertScriptElement = _(changeElementOnDropdownChange.doInsertScriptElement).bind(context);
+
+  pasteUtils.markStylesToBeDisabledOnPaste(CSS_TO_BE_DISABLED_ON_PASTE);
 }
 
 exports.aceEditorCSS = function() {


### PR DESCRIPTION
Also simplify styles that don't affect paste.

This is part of a broader fix, please look for a branch named "fix/paste_long_script" on other plugins:

* https://github.com/storytouch/ep_script_toggle_view/pull/31
* https://github.com/storytouch/ep_script_elements/pull/22
* https://github.com/storytouch/ep_script_page_view/pull/11
* https://github.com/storytouch/ep_script_scene_marks/pull/49
* https://github.com/storytouch/ep_script_copy_cut_paste/pull/14

Part of the fix for https://trello.com/c/rW0dIo24/1334.