### PR TITLE
[feat] Schedule trigger that script length has changed.

### DIFF
--- a/static/js/calculateSceneEdgesLength.js
+++ b/static/js/calculateSceneEdgesLength.js
@@ -5,7 +5,7 @@ var scheduler = require('./scheduler');
 var utils = require('./utils');
 
 var TIMEOUT_TO_CLEAN_DIMENSIONS = 840;
-var TIMEOUT_TO_TRIGGER_MESSAGE_SCRIPT_LENGTH = 840;
+var TIMEOUT_TO_TRIGGER_MESSAGE_SCRIPT_LENGTH = 880;
 
 var calculateSceneEdgesLength = function() {
   this._timeoutToCleanDimensions = TIMEOUT_TO_CLEAN_DIMENSIONS; // allow to override on tests


### PR DESCRIPTION
This PR adds a new trigger for the event `SCRIPT_LENGTH_CHANGED`. Whenever a line is added or removed in the pad, a scheduler is created to trigger this event.

This new trigger is being used to recalculate the total lines in the pad and send this new value trough API, as it is in `ep_script_simple_page_view/static/js/calculateScriptLength.js`.

Implements part of the [card 2078](https://trello.com/c/aft2HizN).