### PR TITLE
[feat] Mark all scenes with a unique identifier

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -252,7 +252,7 @@ var buildScriptElementClasses = function(cls) {
   // sceneId
   var sceneId = shared.SCENE_ID_REGEXP.exec(cls);
   if (sceneId) {
-    const sceneIdClass = shared.SCENE_ID_KEY_ATTRIB + sceneId[0];
+    var sceneIdClass = shared.SCENE_ID_KEY_ATTRIB + sceneId[0];
     classes.push(sceneIdClass);
   }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -21,6 +21,7 @@ var calculateSceneLength          = require('./calculateSceneLength');
 var calculateSceneEdgesLength     = require('./calculateSceneEdgesLength');
 var sceneDuration                 = require('./sceneDuration');
 var scenesLength                  = require('./scenesLength');
+var sceneUniqueIdTagging          = require('./scenesUniqueIdTagging');
 
 var tags = shared.tags;
 var sceneTag = shared.sceneTag;
@@ -65,6 +66,9 @@ exports.aceEditEvent = function(hook, context) {
   if (padHasLoadedCompletely && (isFirstTimeSceneLengthCalculationRunAfterLoading || isAChangeOnPadContent(eventType, callstack) )) {
     isFirstTimeSceneLengthCalculationRunAfterLoading = false;
     updateSceneLengthSchedule.schedule();
+
+    // mark scenes ids after loading script
+    utils.getThisPluginProps().sceneUniqueIdTagging.markScenesWithUniqueId();
   }
 }
 
@@ -95,6 +99,8 @@ exports.postAceInit = function(hook, context) {
   var thisPlugin = utils.getThisPluginProps();
   thisPlugin.calculateSceneEdgesLength = calculateSceneEdgesLength.init();
   thisPlugin.scenesLength = scenesLength.init();
+
+  thisPlugin.sceneUniqueIdTagging = ace_sceneUniqueIdTagging();
 
   // provide access to other plugins
   thisPlugin.calculateSceneLength = ace_calculateSceneLength();
@@ -182,6 +188,8 @@ exports.aceAttribsToClasses = function(hook, context) {
     return [ undoPagination.UNDO_FIX_ATTRIB ];
   } else if (context.key === shared.SCENE_DURATION_ATTRIB_NAME)  {
     return [ shared.SCENE_DURATION_ATTRIB_NAME + ':' + context.value ]; // e.g. sceneDuration:60
+  } else if (context.key === shared.SCENE_ID_KEY_ATTRIB)  {
+    return [ shared.SCENE_DURATION_ATTRIB_NAME, context.value ];
   }
 }
 
@@ -221,7 +229,6 @@ var findExtraFlagForLine = function($node) {
 // Here we convert the class script_element:heading into a tag
 var processScriptElementAttribute = function(cls) {
   var scriptElementType = /(?:^| )script_element:([A-Za-z0-9]*)/.exec(cls);
-  var sceneDurationInSeconds = /(?:^| )sceneDuration:([0-9 \/]+)/.exec(cls);
   var tagIndex;
 
   if (scriptElementType) tagIndex = _.indexOf(tags, scriptElementType[1]);
@@ -229,25 +236,37 @@ var processScriptElementAttribute = function(cls) {
   if (tagIndex !== undefined && tagIndex >= 0) {
     var tag = tags[tagIndex];
     var modifier = {
-      preHtml: '<' + tag + buildSceneMetricClass(sceneDurationInSeconds) + '>',
+      preHtml: '<' + tag + buildScriptElementClasses(cls) + '>',
       postHtml: '</' + tag + '>',
-      processedMarker: true
+      processedMarker: true,
     };
     return [modifier];
   }
 
   return [];
-}
+};
 
-// we only add this class on headings
-var buildSceneMetricClass = function(sceneDurationInSeconds) {
-  var sceneMetricClass = '';
-  if (sceneDurationInSeconds) {
-    var sceneDurationClass = sceneDurationInSeconds ? shared.SCENE_DURATION_CLASS_PREFIX + sceneDurationInSeconds[1] : '';
-    sceneMetricClass = ` class="${sceneDurationClass}"`
+var buildScriptElementClasses = function(cls) {
+  var classes = [];
+
+  // sceneId
+  var sceneId = shared.SCENE_ID_REGEXP.exec(cls);
+  if (sceneId) {
+    const sceneIdClass = shared.SCENE_ID_KEY_ATTRIB + sceneId[0];
+    classes.push(sceneIdClass);
   }
-  return sceneMetricClass;
-}
+
+  // scene duration
+  var sceneDurationInSeconds = /(?:^| )sceneDuration:([0-9 \/]+)/.exec(cls);
+  if (sceneDurationInSeconds) {
+    var sceneDurationClass = sceneDurationInSeconds
+      ? shared.SCENE_DURATION_CLASS_PREFIX + sceneDurationInSeconds[1]
+      : '';
+    classes.push(sceneDurationClass);
+  }
+
+  return classes.length > 0 ? ` class="${classes.join(' ')}"` : '';
+};
 
 var processUndoFixAttribute = function(cls) {
   if (cls.includes(undoPagination.UNDO_FIX_ATTRIB)) {
@@ -268,9 +287,10 @@ var processUndoFixAttribute = function(cls) {
 exports.aceInitialized = function(hook, context) {
   var editorInfo = context.editorInfo;
 
+  ace_calculateSceneLength = _(calculateSceneLength.init).bind(context);
+  ace_sceneUniqueIdTagging = _(sceneUniqueIdTagging.init).bind(context);
   editorInfo.ace_removeSceneTagFromSelection = _(removeSceneTagFromSelection).bind(context);
   editorInfo.ace_doInsertScriptElement = _(changeElementOnDropdownChange.doInsertScriptElement).bind(context);
-  ace_calculateSceneLength = _(calculateSceneLength.init).bind(context);
   editorInfo.ace_addSceneDurationAttribute = _(sceneDuration.addSceneDurationAttribute).bind(context);
   editorInfo.ace_caretElementChangeSendMessage = _(caretElementChange.sendMessageCaretElementChanged).bind(context);
 

--- a/static/js/scenesUniqueIdTagging.js
+++ b/static/js/scenesUniqueIdTagging.js
@@ -1,0 +1,66 @@
+var _ = require('ep_etherpad-lite/static/js/underscore');
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+
+var utils = require('./utils');
+var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
+var linesChangedListener = require('ep_comments_page/static/js/linesChangedListener');
+
+var HEADING_WITHOUT_SCENE_ID_SELECTOR = 'heading:not(.scene-id)';
+var LINES_CHANGED_LISTENER_TIMEOUT = 800;
+var SCENE_ID_KEY_ATTRIB = require('./shared').SCENE_ID_KEY_ATTRIB;
+var SCENE_ID_PREFIX = require('./shared').SCENE_ID_PREFIX;
+var SCENE_ID_REGEXP = require('./shared').SCENE_ID_REGEXP;
+
+var sceneUniqueIdTagging = function(editorInfo, documentAttributeManager, rep) {
+  var self = this;
+  self.editorInfo = editorInfo;
+  self.attributeManager = documentAttributeManager;
+  self.rep = rep;
+  linesChangedListener.onLineChanged(
+    HEADING_WITHOUT_SCENE_ID_SELECTOR,
+    this.markScenesWithUniqueId.bind(this),
+    LINES_CHANGED_LISTENER_TIMEOUT
+  );
+};
+
+sceneUniqueIdTagging.prototype._generateSceneId = function() {
+  return SCENE_ID_PREFIX + randomString(16);
+};
+
+sceneUniqueIdTagging.prototype._placeCaretOnLine = function(newSelStart, newSelEnd) {
+  var self = this;
+
+  // in case no newSelEnd is provided, place caret at newSelStart
+  newSelEnd = newSelEnd || newSelStart;
+
+  self.editorInfo.ace_inCallStackIfNecessary('SceneMarkPlaceCaretOnLine', function() {
+    self.editorInfo.ace_performSelectionChange(newSelStart, newSelEnd, true);
+    self.editorInfo.ace_updateBrowserSelectionFromRep();
+  });
+};
+
+sceneUniqueIdTagging.prototype._markSceneWithUniqueId = function(element, $lines) {
+  var lineNumber = $lines.index(element);
+  var sceneId = this._generateSceneId();
+  var caretLine = this.rep.selStart[0];
+  this.attributeManager.setAttributeOnLine(lineNumber, SCENE_ID_KEY_ATTRIB, sceneId);
+};
+
+sceneUniqueIdTagging.prototype.markScenesWithUniqueId = function() {
+  var self = this;
+  self.editorInfo.ace_inCallStackIfNecessary('markScenesWithUniqueId', function() {
+    var padInner = utils.getPadInner();
+    var $lines = padInner.find('div');
+    var $headings = padInner.find(HEADING_WITHOUT_SCENE_ID_SELECTOR).parent();
+    $headings.each(function(index, element) {
+      self._markSceneWithUniqueId(element, $lines);
+    });
+  });
+};
+
+exports.init = function() {
+  var editorInfo = this.editorInfo;
+  var documentAttributeManager = this.documentAttributeManager;
+  var rep = this.rep;
+  return new sceneUniqueIdTagging(editorInfo, documentAttributeManager, rep);
+};

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -9,6 +9,10 @@ var SCENE_DURATION_ATTRIB_NAME = 'sceneDuration';
 // from sceneDuration-30 gets '30'
 var SCENE_DURATION_REGEXP = new RegExp(SCENE_DURATION_CLASS_PREFIX + '([0-9]+)');
 
+var SCENE_ID_KEY_ATTRIB = 'scene-id';
+var SCENE_ID_PREFIX = 'scid-';
+var SCENE_ID_REGEXP = new RegExp('(?:^| )' + SCENE_ID_PREFIX + '[A-Za-z0-9]+');
+
 var collectContentPre = function(hook, context){
   var tname = context.tname;
   var state = context.state;
@@ -22,6 +26,12 @@ var collectContentPre = function(hook, context){
 
   if (isScriptElement(tname)) {
     lineAttributes['script_element'] = tname;
+
+    // collect scene id
+    var sceneId = SCENE_ID_REGEXP.exec(context.cls);
+    if (sceneId) {
+      lineAttributes[SCENE_ID_KEY_ATTRIB] = sceneId[0];
+    }
 
     // collect scene metric
     var sceneDuration = SCENE_DURATION_REGEXP.exec(cls);
@@ -63,3 +73,6 @@ exports.tags = tags;
 exports.sceneTag = sceneTag;
 exports.SCENE_DURATION_ATTRIB_NAME = SCENE_DURATION_ATTRIB_NAME;
 exports.SCENE_DURATION_CLASS_PREFIX  = SCENE_DURATION_CLASS_PREFIX;
+exports.SCENE_ID_KEY_ATTRIB = SCENE_ID_KEY_ATTRIB;
+exports.SCENE_ID_PREFIX = SCENE_ID_PREFIX;
+exports.SCENE_ID_REGEXP = SCENE_ID_REGEXP;

--- a/static/tests/frontend/specs/scenesUniqueIdTagging.js
+++ b/static/tests/frontend/specs/scenesUniqueIdTagging.js
@@ -1,0 +1,137 @@
+describe('ep_script_elements - scenes unique id tagging', function() {
+  var helperFunctions, padId;
+  var sceneNavigatorUtils;
+
+  var FIRST_SCENE_LINE = 2;
+
+  before(function(done) {
+    helperFunctions = ep_script_elements_test_helper.generalTests;
+    sceneNavigatorUtils = ep_scene_navigator_test_helper.utils;
+
+    padId = helper.newPad(function() {
+      helperFunctions.createScript(function() {
+        ep_scene_navigator_test_helper.utils.enableAllEASCButtons(done);
+      });
+    });
+    this.timeout(20000);
+  });
+
+  context('when the pad is completely loaded', function() {
+    var padSceneIds;
+
+    before(function(done) {
+      helperFunctions.getSceneIds(function(sceneIds) {
+        padSceneIds = sceneIds;
+        done();
+      });
+    });
+
+    it('sets a unique for each heading', function(done) {
+      expect(padSceneIds.length).to.be(2);
+      expect(helperFunctions.hasOnlyUniqueEntries(padSceneIds)).to.be(true);
+      done();
+    });
+
+    context('and user reloads the pad', function() {
+      var padSceneIdsAfterReload;
+
+      before(function(done) {
+        helperFunctions.reloadPad(padId, function() {
+          helperFunctions.getSceneIds(function(sceneIds) {
+            padSceneIdsAfterReload = sceneIds;
+            done();
+          });
+        });
+      });
+
+      it('does not change the scene ids', function(done) {
+        expect(padSceneIds).to.eql(padSceneIdsAfterReload);
+        done();
+      });
+    });
+
+    context('when user adds a SCENE', function() {
+      var padSceneIdsAfterCreatingNewScene;
+
+      before(function(done) {
+        helperFunctions.addSceneAbove(FIRST_SCENE_LINE, function() {
+          helperFunctions.getSceneIds(function(sceneIds) {
+            padSceneIdsAfterCreatingNewScene = sceneIds;
+            done();
+          });
+        });
+      });
+
+      it('creates a new id for the new heading', function(done) {
+        expect(padSceneIdsAfterCreatingNewScene.length).to.be(3);
+        expect(helperFunctions.hasOnlyUniqueEntries(padSceneIdsAfterCreatingNewScene)).to.be(true);
+        done();
+      });
+
+      it('keeps the caret in the new heading line', function(done) {
+        var newHeadingLineNumber = 2;
+        expect(helperFunctions.getLineNumberWhereCaretIs()).to.be(newHeadingLineNumber);
+        done();
+      });
+    });
+  });
+});
+
+var ep_script_elements_test_helper = ep_script_elements_test_helper || {};
+ep_script_elements_test_helper.generalTests = {
+  createScript: function(cb) {
+    var SMUtils = ep_script_scene_marks_test_helper.utils;
+    SMUtils.cleanPad(function() {
+      var firstScene = SMUtils.createSynopsis('heading 1');
+      var action = SMUtils.action('first action');
+      var secondScene = SMUtils.createSynopsis('heading 2');
+      var dialogue = SMUtils.dialogue('last');
+      var script = firstScene + action + secondScene + dialogue;
+      SMUtils.createScriptWith(script, 'last', cb);
+    });
+  },
+  reloadPad: function(targetPadId, done) {
+    return helper.newPad(function() {
+      ep_scene_navigator_test_helper.utils.enableAllEASCButtons(done);
+    }, targetPadId);
+  },
+  addSceneAbove: function(line, cb) {
+    shortcutAddSceneMark.MOUSE.addSceneAbove(line, cb);
+  },
+  getSceneIds: function(cb) {
+    helper
+      .waitFor(function() {
+        var $headings = helper.padInner$('heading.scene-id');
+        return $headings.length;
+      })
+      .done(function() {
+        // from 'scene-id scid-A8B6RzMlZg0wHr9O' gets 'scid-A8B6RzMlZg0wHr9O'
+        var sceneIds = [];
+        var sceneIdRegex = new RegExp('scene-id (scid-[A-Za-z0-9]+)');
+        var $headings = helper.padInner$('heading.scene-id');
+        $headings.each(function(index, element) {
+          var headingClass = helper.padInner$(element).attr('class');
+          var sceneId = sceneIdRegex.exec(headingClass);
+          if (sceneId && sceneId.length) sceneIds.push(sceneId[1]);
+        });
+        cb(sceneIds);
+      });
+  },
+  hasOnlyUniqueEntries: function(array) {
+    return _.uniq(array).length === array.length;
+  },
+  _getNodeWhereCaretIs: function() {
+    return helper.padInner$.document.getSelection().anchorNode;
+  },
+  getLineWhereCaretIs: function() {
+    var nodeWhereCaretIs = this._getNodeWhereCaretIs();
+    var $lineWhereCaretIs = $(nodeWhereCaretIs)
+      .parents('div')
+      .last();
+    return $lineWhereCaretIs;
+  },
+  getLineNumberWhereCaretIs: function() {
+    var $lineWhereCaretIs = this.getLineWhereCaretIs();
+    return $lineWhereCaretIs.index();
+  },
+};


### PR DESCRIPTION
This PR adds a unique id for each `heading` in the script, as follow:
```html
<heading class="scene-id scid-nUf568qzlAvXOOe7"> ... </heading>
```
This ID is persisted as an attribute, so it remais in the element after reloading the pad.

Depends on https://github.com/storytouch/ep_comments/pull/67.
Implements part of the [card 2079](https://trello.com/c/g58BtVlo).