### PR TITLE
[feat] Creates a pad type checking module

### DIFF
--- a/static/js/padType.js
+++ b/static/js/padType.js
@@ -1,0 +1,41 @@
+var shared = require('./shared');
+
+var PAD_TYPE_URL_PARAM = 'padType';
+var BACKUP_DOCUMENT_TYPE = shared.BACKUP_DOCUMENT_TYPE;
+var SCRIPT_DOCUMENT_TYPE = shared.SCRIPT_DOCUMENT_TYPE;
+
+var padType = function() {
+  // I know it is wierd, ugly and unsafe, but it is necessary
+  // to allow mocking the padType URL parameter in tests.
+  //
+  // So, if you want to test diferent padType values, assign
+  // window._getPadTypeParam = yourMockFunctionThatReturnsAType
+  // before creating a pad, as in .setPadType(type)
+  // ep_script_elements/static/tests/frontend/specs/_utils.js
+  //
+  // See an example at:
+  // ep_mouse_shortcuts/static/tests/frontend/specs/padType.js
+  this.getPadTypeParam = parent._getPadTypeParam || this._getPadTypeParam;
+};
+
+padType.prototype._getPadTypeParam = function() {
+  var params = new URL(window.location.href).searchParams;
+  var padTypeParam = params.get(PAD_TYPE_URL_PARAM);
+};
+
+padType.prototype.isScriptDocumentPad = function() {
+  var padTypeParam = this.getPadTypeParam();
+
+  // considering null types like ScriptDocument
+  // for backward compatibility
+  var padTypeIsScriptDocument =
+    !padTypeParam ||
+    padTypeParam === SCRIPT_DOCUMENT_TYPE ||
+    padTypeParam === BACKUP_DOCUMENT_TYPE;
+
+  return padTypeIsScriptDocument;
+};
+
+exports.init = function() {
+  return new padType();
+};

--- a/static/js/padType.js
+++ b/static/js/padType.js
@@ -5,7 +5,7 @@ var BACKUP_DOCUMENT_TYPE = shared.BACKUP_DOCUMENT_TYPE;
 var SCRIPT_DOCUMENT_TYPE = shared.SCRIPT_DOCUMENT_TYPE;
 
 var padType = function() {
-  // I know it is wierd, ugly and unsafe, but it is necessary
+  // I know it is weird, ugly and unsafe, but it is necessary
   // to allow mocking the padType URL parameter in tests.
   //
   // So, if you want to test diferent padType values, assign

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,5 +1,10 @@
 var _ = require('ep_etherpad-lite/static/js/underscore');
 
+// pad types
+var BACKUP_DOCUMENT_TYPE = 'BackupDocument';
+var SCRIPT_DOCUMENT_TYPE = 'ScriptDocument';
+var TITLE_PAGE_DOCUMENT_TYPE = 'TitlePageDocument';
+
 var tags = ['heading', 'action', 'character', 'parenthetical', 'dialogue', 'transition', 'shot'];
 var sceneTag = ['scene-number', 'scene-duration', 'scene-temporality', 'scene-workstate', 'scene-time'];
 
@@ -75,6 +80,9 @@ exports.collectContentPre = collectContentPre;
 exports.collectContentPost = collectContentPost;
 exports.tags = tags;
 exports.sceneTag = sceneTag;
+exports.SCRIPT_DOCUMENT_TYPE = SCRIPT_DOCUMENT_TYPE;
+exports.BACKUP_DOCUMENT_TYPE = BACKUP_DOCUMENT_TYPE;
+exports.TITLE_PAGE_DOCUMENT_TYPE = TITLE_PAGE_DOCUMENT_TYPE;
 exports.SCENE_DURATION_ATTRIB_NAME = SCENE_DURATION_ATTRIB_NAME;
 exports.SCENE_DURATION_CLASS_PREFIX  = SCENE_DURATION_CLASS_PREFIX;
 exports.SCENE_ID_KEY_ATTRIB = SCENE_ID_KEY_ATTRIB;

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -377,4 +377,18 @@ ep_script_elements_test_helper.utils = {
     this.thisPlugin().calculateSceneEdgesLength._timeoutToCleanDimensions = 0;
   },
 
+  // padTypes
+  BACKUP_DOCUMENT_TYPE: 'BackupDocument',
+  SCRIPT_DOCUMENT_TYPE: 'ScriptDocument',
+  TITLE_PAGE_DOCUMENT_TYPE: 'TitlePageDocument',
+
+  // used to mock the pad type
+  _getPadTypeParamMocked: function(type) {
+    return function() {
+      return type;
+    };
+  },
+  setPadType: function(type) {
+    window._getPadTypeParam = this._getPadTypeParamMocked(type);
+  }
 };


### PR DESCRIPTION
This PR creates a `padType` checking module and helpers to allow mocking the `padType` URL parameter in tests.

Implements part of the [card 2050](https://trello.com/c/08KTQ9HF).