### PR TITLE
[test] Improves pad type detection

### DIFF
--- a/static/js/padType.js
+++ b/static/js/padType.js
@@ -5,26 +5,21 @@ var BACKUP_DOCUMENT_TYPE = shared.BACKUP_DOCUMENT_TYPE;
 var SCRIPT_DOCUMENT_TYPE = shared.SCRIPT_DOCUMENT_TYPE;
 
 var padType = function() {
-  // I know it is weird, ugly and unsafe, but it is necessary
-  // to allow mocking the padType URL parameter in tests.
-  //
-  // So, if you want to test diferent padType values, assign
-  // window._getPadTypeParam = yourMockFunctionThatReturnsAType
-  // before creating a pad, as in .setPadType(type)
-  // ep_script_elements/static/tests/frontend/specs/_utils.js
-  //
-  // See an example at:
-  // ep_mouse_shortcuts/static/tests/frontend/specs/padType.js
-  this.getPadTypeParam = parent._getPadTypeParam || this._getPadTypeParam;
+  this._cachedPadTypeParam = null;
 };
 
 padType.prototype._getPadTypeParam = function() {
-  var params = new URL(window.location.href).searchParams;
-  var padTypeParam = params.get(PAD_TYPE_URL_PARAM);
+  if (!this._cachedPadTypeParam) {
+    // caches the pad type to avoid over-processing
+    var params = new URL(window.location.href).searchParams;
+    var padTypeParam = params.get(PAD_TYPE_URL_PARAM);
+    this._cachedPadTypeParam = padTypeParam;
+  }
+  return this._cachedPadTypeParam;
 };
 
 padType.prototype.isScriptDocumentPad = function() {
-  var padTypeParam = this.getPadTypeParam();
+  var padTypeParam = this._getPadTypeParam();
 
   // considering null types like ScriptDocument
   // for backward compatibility

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -381,14 +381,4 @@ ep_script_elements_test_helper.utils = {
   BACKUP_DOCUMENT_TYPE: 'BackupDocument',
   SCRIPT_DOCUMENT_TYPE: 'ScriptDocument',
   TITLE_PAGE_DOCUMENT_TYPE: 'TitlePageDocument',
-
-  // used to mock the pad type
-  _getPadTypeParamMocked: function(type) {
-    return function() {
-      return type;
-    };
-  },
-  setPadType: function(type) {
-    window._getPadTypeParam = this._getPadTypeParamMocked(type);
-  }
 };

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -381,4 +381,9 @@ ep_script_elements_test_helper.utils = {
   BACKUP_DOCUMENT_TYPE: 'BackupDocument',
   SCRIPT_DOCUMENT_TYPE: 'ScriptDocument',
   TITLE_PAGE_DOCUMENT_TYPE: 'TitlePageDocument',
+
+  newPadWithType: function(cb, type) {
+    var padName = "FRONTEND_TEST_" + helper.randomString(20);
+    helper.newPad(cb, `${padName}?padType=${type}`);
+  },
 };


### PR DESCRIPTION
This PR improves pad type detection by removing unsafe code and caching the `padType` URL parameter to avoid over-processing.

It also improves the pad type mocking helper by setting URL parameters in the iframe.