### PR TITLE
[refactor] Moves the padType to the preLoader hook

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -1,8 +1,15 @@
 {
   "parts": [
     {
+      "comment": "This part has all the modules that must be loaded at the beginning",
+      "name": "preLoader",
+      "client_hooks": {
+        "documentReady": "ep_script_elements/static/js/preLoader"
+      }
+    },
+    {
       "name": "main",
-      "pre": ["ep_font_color/main", "ep_comments_page/comments_page"],
+      "pre": ["ep_script_elements/preLoader", "ep_font_color/main", "ep_comments_page/comments_page"],
       "client_hooks": {
         "aceEditorCSS": "ep_script_elements/static/js/aceEditorCSS",
         "aceSelectionChanged": "ep_script_elements/static/js/index",

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -22,7 +22,6 @@ var calculateSceneEdgesLength     = require('./calculateSceneEdgesLength');
 var sceneDuration                 = require('./sceneDuration');
 var scenesLength                  = require('./scenesLength');
 var sceneUniqueIdTagging          = require('./scenesUniqueIdTagging');
-var padType                       = require('./padType');
 
 var tags = shared.tags;
 var sceneTag = shared.sceneTag;
@@ -98,7 +97,6 @@ var eventMightBeAnUndo = function(callstack) {
 exports.postAceInit = function(hook, context) {
   var ace = context.ace;
   var thisPlugin = utils.getThisPluginProps();
-  thisPlugin.padType = padType.init();
   thisPlugin.calculateSceneEdgesLength = calculateSceneEdgesLength.init();
   thisPlugin.scenesLength = scenesLength.init();
 

--- a/static/js/preLoader.js
+++ b/static/js/preLoader.js
@@ -1,0 +1,8 @@
+var utils                         = require('./utils');
+var padType                       = require('./padType');
+
+// this hook proxies the functionality of jQuery's $(document).ready event
+exports.documentReady = function() {
+  var thisPlugin = utils.getThisPluginProps();
+  thisPlugin.padType = padType.init();
+}


### PR DESCRIPTION
It creates a new hook called preLoader, which is initialized before all other hooks. It is necessary to allow other plugins to use the `padType` identifier during the plug-in's initialization.