### PR TITLE
[refactor] Allow bypassing line attributes processing

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -25,9 +25,14 @@
       "hooks": {
         "collectContentPre": "ep_script_elements/static/js/shared",
         "collectContentPost": "ep_script_elements/static/js/shared",
-        "getLineHTMLForExport": "ep_script_elements/index",
         "stylesForExport" : "ep_script_elements/index",
         "socketio": "ep_script_elements/index"
+      }
+    },
+    {
+      "name": "getLineHTMLForExport",
+      "hooks": {
+        "getLineHTMLForExport": "ep_script_elements/index"
       }
     },
     {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ exports.getLineHTMLForExport = function (hook, context) {
   //try to find a scene line attributes. if it's found it mounts the HTML with it
   var script_element = findAttrib(attribLine, apool, "script_element");
   var text = context.lineContent;
-  if (script_element) {
+  if (script_element && !context.lineAttribsProcessed) {
     text = text.substring(1);
   } else { // if it is not a script nor a scene mark, then it is a general
     script_element = "general";


### PR DESCRIPTION
This PR updates the `getLineHTMLForExport` hook to allow bypassing line attributes processing. These changes were necessary to meet the requirements of https://github.com/storytouch/ep_align/pull/5.

Implements part of the [card 2237](https://trello.com/c/FrbBtWRx).