### PR TITLE
[test] Adds TextDocument constant

### DIFF
--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -377,6 +377,7 @@ ep_script_elements_test_helper.utils = {
   // padTypes
   BACKUP_DOCUMENT_TYPE: 'BackupDocument',
   SCRIPT_DOCUMENT_TYPE: 'ScriptDocument',
+  TEXT_DOCUMENT_TYPE: 'TextDocument',
   TITLE_PAGE_DOCUMENT_TYPE: 'TitlePageDocument',
 
   newPadWithType: function(cb, type) {


### PR DESCRIPTION
This PR adds the `TEXT_DOCUMENT_TYPE` constant into the tests `utils`.

It's related to the [card 2048](https://trello.com/c/bVljeP9j).