### PR TITLE
[feat] Adds the new TextDocument pad type

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -267,6 +267,12 @@ exports.aceInitialized = function(hook, context) {
   thisPlugin.reformatWindowState = reformatWindowState.init();
 
   pasteUtils.markStylesToBeDisabledOnPaste(CSS_TO_BE_DISABLED_ON_PASTE);
+
+  // adds a class on the inner iframe with the pad type
+  var padTypeParam = thisPlugin.padType.getPadTypeParam();
+  if (padTypeParam) {
+    utils.getPadInner().find('#innerdocbody').addClass(padTypeParam);
+  }
 }
 
 // Find out which lines are selected and remove scenetag from them

--- a/static/js/padType.js
+++ b/static/js/padType.js
@@ -3,6 +3,7 @@ var shared = require('./shared');
 var PAD_TYPE_URL_PARAM = 'padType';
 var BACKUP_DOCUMENT_TYPE = shared.BACKUP_DOCUMENT_TYPE;
 var SCRIPT_DOCUMENT_TYPE = shared.SCRIPT_DOCUMENT_TYPE;
+var TEXT_DOCUMENT_TYPE = shared.TEXT_DOCUMENT_TYPE;
 
 var padType = function() {
   this._cachedPadTypeParam = null;
@@ -29,6 +30,11 @@ padType.prototype.isScriptDocumentPad = function() {
     padTypeParam === BACKUP_DOCUMENT_TYPE;
 
   return padTypeIsScriptDocument;
+};
+
+padType.prototype.isTextDocumentPad = function() {
+  var padTypeParam = this._getPadTypeParam();
+  return padTypeParam === TEXT_DOCUMENT_TYPE;
 };
 
 exports.init = function() {

--- a/static/js/padType.js
+++ b/static/js/padType.js
@@ -9,7 +9,7 @@ var padType = function() {
   this._cachedPadTypeParam = null;
 };
 
-padType.prototype._getPadTypeParam = function() {
+padType.prototype.getPadTypeParam = function() {
   if (!this._cachedPadTypeParam) {
     // caches the pad type to avoid over-processing
     var params = new URL(window.location.href).searchParams;
@@ -20,7 +20,7 @@ padType.prototype._getPadTypeParam = function() {
 };
 
 padType.prototype.isScriptDocumentPad = function() {
-  var padTypeParam = this._getPadTypeParam();
+  var padTypeParam = this.getPadTypeParam();
 
   // considering null types like ScriptDocument
   // for backward compatibility
@@ -33,7 +33,7 @@ padType.prototype.isScriptDocumentPad = function() {
 };
 
 padType.prototype.isTextDocumentPad = function() {
-  var padTypeParam = this._getPadTypeParam();
+  var padTypeParam = this.getPadTypeParam();
   return padTypeParam === TEXT_DOCUMENT_TYPE;
 };
 

--- a/static/js/preLoader.js
+++ b/static/js/preLoader.js
@@ -1,5 +1,5 @@
-var utils                         = require('./utils');
-var padType                       = require('./padType');
+var utils   = require('./utils');
+var padType = require('./padType');
 
 // this hook proxies the functionality of jQuery's $(document).ready event
 exports.documentReady = function() {

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -6,6 +6,7 @@ var SCRIPT_ELEMENTS_ATTRIBUTE_NAME = 'script_element';
 var BACKUP_DOCUMENT_TYPE = 'BackupDocument';
 var SCRIPT_DOCUMENT_TYPE = 'ScriptDocument';
 var TITLE_PAGE_DOCUMENT_TYPE = 'TitlePageDocument';
+var TEXT_DOCUMENT_TYPE = 'TextDocument';
 
 var tags = ['heading', 'action', 'character', 'parenthetical', 'dialogue', 'transition', 'shot'];
 var sceneTag = ['scene-number', 'scene-duration', 'scene-temporality', 'scene-workstate', 'scene-time'];
@@ -86,6 +87,7 @@ exports.SCRIPT_ELEMENTS_ATTRIBUTE_NAME = SCRIPT_ELEMENTS_ATTRIBUTE_NAME;
 exports.SCRIPT_DOCUMENT_TYPE = SCRIPT_DOCUMENT_TYPE;
 exports.BACKUP_DOCUMENT_TYPE = BACKUP_DOCUMENT_TYPE;
 exports.TITLE_PAGE_DOCUMENT_TYPE = TITLE_PAGE_DOCUMENT_TYPE;
+exports.TEXT_DOCUMENT_TYPE = TEXT_DOCUMENT_TYPE;
 exports.SCENE_DURATION_ATTRIB_NAME = SCENE_DURATION_ATTRIB_NAME;
 exports.SCENE_DURATION_CLASS_PREFIX  = SCENE_DURATION_CLASS_PREFIX;
 exports.SCENE_ID_KEY_ATTRIB = SCENE_ID_KEY_ATTRIB;

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -21,7 +21,25 @@ var SCENE_ID_KEY_ATTRIB = 'scene-id';
 var SCENE_ID_PREFIX = 'scid-';
 var SCENE_ID_REGEXP = new RegExp('(?:^| )' + SCENE_ID_PREFIX + '[A-Za-z0-9]+');
 
+var isScriptDocumentPad = function() {
+  let pad = global.pad || null;
+
+  // if it is called in the client side (browser)
+  if (pad && pad.plugins && pad.plugins.ep_script_elements && pad.plugins.ep_script_elements.padType) {
+    return pad.plugins.ep_script_elements.padType.isScriptDocumentPad();
+  }
+
+  // TODO: how to assess the padType in the server side?
+  return true;
+};
+
 var collectContentPre = function(hook, context){
+  // it collects all script-elements attributes for non-ScriptDocument
+  // pads. It covers the scenario where a user copies a text with script
+  // elements and pastes it on a non-ScriptDocument pad. It will clean
+  // all these attributes before pasting the content.
+  if (!isScriptDocumentPad()) return;
+
   var tname = context.tname;
   var state = context.state;
   var lineAttributes = state.lineAttributes
@@ -52,13 +70,13 @@ var collectContentPre = function(hook, context){
 };
 
 // I don't even know when this is run..
-var collectContentPost = function(hook, context){
+var collectContentPost = function(hook, context) {
   var tname = context.tname;
   var state = context.state;
-  var lineAttributes = state.lineAttributes
+  var lineAttributes = state.lineAttributes;
   var tagIndex = _.indexOf(tags, tname);
 
-  if(tagIndex >= 0){
+  if (tagIndex >= 0) {
     //take line-attributes used away - script_element and scenesData[]
     //all elements in the tags array uses script_element as key of lineattributes
     resetLineAttributes(lineAttributes);
@@ -66,18 +84,22 @@ var collectContentPost = function(hook, context){
 };
 
 var resetLineAttributes = function(lineAttributes) {
-  var usedLineAttributes = _.union(sceneTag, [SCRIPT_ELEMENTS_ATTRIBUTE_NAME, SCENE_DURATION_ATTRIB_NAME, SCENE_ID_KEY_ATTRIB])
-  for (var i = 0; i < usedLineAttributes.length ; i++) {
+  var usedLineAttributes = _.union(sceneTag, [
+    SCRIPT_ELEMENTS_ATTRIBUTE_NAME,
+    SCENE_DURATION_ATTRIB_NAME,
+    SCENE_ID_KEY_ATTRIB,
+  ]);
+  for (var i = 0; i < usedLineAttributes.length; i++) {
     delete lineAttributes[usedLineAttributes[i]];
   }
-}
+};
 
 var isSceneTag = function(tname) {
   return _.indexOf(sceneTag, tname) >= 0;
-}
+};
 var isScriptElement = function(tname) {
   return _.indexOf(tags, tname) >= 0;
-}
+};
 
 exports.collectContentPre = collectContentPre;
 exports.collectContentPost = collectContentPost;
@@ -89,7 +111,7 @@ exports.BACKUP_DOCUMENT_TYPE = BACKUP_DOCUMENT_TYPE;
 exports.TITLE_PAGE_DOCUMENT_TYPE = TITLE_PAGE_DOCUMENT_TYPE;
 exports.TEXT_DOCUMENT_TYPE = TEXT_DOCUMENT_TYPE;
 exports.SCENE_DURATION_ATTRIB_NAME = SCENE_DURATION_ATTRIB_NAME;
-exports.SCENE_DURATION_CLASS_PREFIX  = SCENE_DURATION_CLASS_PREFIX;
+exports.SCENE_DURATION_CLASS_PREFIX = SCENE_DURATION_CLASS_PREFIX;
 exports.SCENE_ID_KEY_ATTRIB = SCENE_ID_KEY_ATTRIB;
 exports.SCENE_ID_PREFIX = SCENE_ID_PREFIX;
 exports.SCENE_ID_REGEXP = SCENE_ID_REGEXP;

--- a/static/tests/frontend/specs/copyPaste.js
+++ b/static/tests/frontend/specs/copyPaste.js
@@ -1,0 +1,91 @@
+describe('ep_script_elements - copy/paste', function() {
+  var helperFunctions, utils;
+
+  before(function(done) {
+    utils = ep_script_elements.utils;
+    helperFunctions = ep_script_elements.copyPaste;
+    done();
+  });
+
+  context('when user copies a text with script elements', function() {
+    before(function(done) {
+      helperFunctions.createScriptDocumentPad(function(callback) {
+        helperFunctions.copyAllContent();
+        done();
+      });
+
+      this.timeout(60000);
+    });
+
+    context('and pastes in a TextDocumentPad', function() {
+      before(function(done) {
+        helperFunctions.createTextDocumentPad(function() {
+          helperFunctions.pasteAfterLine(0, done);
+        });
+        this.timeout(5000);
+      });
+
+      it('preserves the text content', function(done) {
+        helper
+          .waitFor(function() {
+            var isFirstLineTextPreserved = helper.padInner$('div').eq(9).text() === 'scene';
+            var isSecondLineTextPreserved = helper.padInner$('div').eq(10).text() === 'action';
+            return isFirstLineTextPreserved && isSecondLineTextPreserved;
+          })
+          .done(done);
+      });
+
+      it('does not preserve script element types', function(done) {
+        helper
+          .waitFor(function() {
+            var isHeadingTypeRemoved = helper.padInner$('heading').length === 0;
+            var isActionTypeRemoved = helper.padInner$('action').length === 0;
+            return isHeadingTypeRemoved && isActionTypeRemoved;
+          })
+          .done(done);
+      });
+    });
+  });
+});
+
+var ep_script_elements = ep_script_elements || {};
+ep_script_elements.copyPaste = {
+  createTextDocumentPad: function(cb) {
+    var epSEUtils = ep_script_elements_test_helper.utils;
+    var padType = epSEUtils.TEXT_DOCUMENT_TYPE;
+    epSEUtils.newPadWithType(cb, padType);
+  },
+  createScriptDocumentPad: function(cb) {
+    var epSEUtils = ep_script_elements_test_helper.utils;
+    var epSMUtils = ep_script_scene_marks_test_helper.utils;
+    var padType = epSEUtils.SCRIPT_DOCUMENT_TYPE;
+    epSEUtils.newPadWithType(function() {
+      var episode = epSMUtils.createEpi('scene');
+      var action = epSMUtils.action('action');
+      var script = episode + action;
+      epSMUtils.createScriptWith(script, 'action', cb);
+    }, padType);
+  },
+  copyAllContent: function(lineNumber) {
+    var $firstLine = helper.padInner$('div').first();
+    var $lastLine = helper.padInner$('div').last();
+    helper.selectLines($firstLine, $lastLine);
+    ep_script_copy_cut_paste_test_helper.utils.copy();
+  },
+  pasteAfterLine: function(lineNumber, cb) {
+    var totalLines = helper.padInner$('div').length;
+
+    // adds a new empty line
+    var $targetLine = helper.padInner$('div').eq(lineNumber);
+    $targetLine.sendkeys('{selectall}{rightarrow}{enter}{enter}');
+
+    helper
+      .waitFor(function() {
+        return helper.padInner$('div').length > totalLines;
+      }, 4000)
+      .done(function() {
+        // paste the content
+        ep_script_copy_cut_paste_test_helper.utils.pasteAtTheEndOfLine(lineNumber + 1, cb);
+      });
+  },
+};


### PR DESCRIPTION
In this PR, we add a new pad type called `TextDocument`.

We also add some helpers to allow other plugins to get the pad type param.

In addition, we add a class with the pad type in the `body#innerdocbody` that will allow the [Export Import Service](https://github.com/storytouch/export-import-service) to use custom styles and params for each pad type.

It's related to the [card 2511](https://trello.com/c/9PvSB7qn).