### PR TITLE
[styles] Adjust elements styles after changing to Courier Prime

### DIFF
--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -13,7 +13,7 @@ heading:before {
   float: left;
   text-align: left;
   display: block;
-  margin-left: -81px; /*aligned with scene mark vertical bottom border*/
+  margin-left: -75px; /* aligned with scene mark vertical bottom border */
 
   /*make the number below the act/seq icon*/
   position: relative;

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -58,6 +58,7 @@ heading, action, character, parenthetical, dialogue, transition, shot {
 #innerdocbody div {
   font-family: 'Courier Prime', monospace;
   font-size: 12pt;
+  width: 705px;
 }
 
 /*
@@ -111,12 +112,6 @@ heading, action, character, parenthetical, dialogue, transition, shot {
  *  Any changes on font-style, such as font-size, font-family, etc, may change the
  *  width of these elements.
  */
-
- /* styles applied to GENERAL element */
-#innerdocbody div > span {
-  width: 586px;
-  display: block;
-}
 
 action {
   margin-top: 20px;

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -60,7 +60,6 @@ heading, action, character, parenthetical, dialogue, transition, shot {
   font-size: 12pt;
 }
 
-
 /*
  *  ===================================================================================
  *                        DIMENSIONS OF SCRIPT ELEMENTS
@@ -112,6 +111,12 @@ heading, action, character, parenthetical, dialogue, transition, shot {
  *  Any changes on font-style, such as font-size, font-family, etc, may change the
  *  width of these elements.
  */
+
+ /* styles applied to GENERAL element */
+#innerdocbody div > span {
+  width: 586px;
+  display: block;
+}
 
 action {
   margin-top: 20px;


### PR DESCRIPTION
This PR is related to [Trello Card 2551](https://trello.com/c/m8TDBTLG/2551-ajustes-visuais-texto-livre).

Decrease margin between scene number and heading because text body requires more space now that we've implemented Courier Prime and its font is larger.  
So we had to decrease margins on the left side of script text so the comment icons column doesn't cut the right part of the text.

Also make GENERAL elements to have the same width of actions, and so, show the same 61 characters per line.
Without defined width, even though ACTION and GENERAL looked the same, the General was sending 1 character to the next line.
