### PR TITLE
[chore] Adds the padType class in the outerdocbody

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -272,6 +272,7 @@ exports.aceInitialized = function(hook, context) {
   var padTypeParam = thisPlugin.padType.getPadTypeParam();
   if (padTypeParam) {
     utils.getPadInner().find('#innerdocbody').addClass(padTypeParam);
+    utils.getPadOuter().find('#outerdocbody').addClass(padTypeParam);
   }
 }
 


### PR DESCRIPTION
This PR adds a class with the `padType` value (eg: `ScriptDocument`) in the `body#outerdocbody` element.
It's useful for other plugins customizing elements through CSS.

Implements part of the [card 2583](https://trello.com/c/SfH011SB).